### PR TITLE
Add STE-based quantizer

### DIFF
--- a/classification/test_time.py
+++ b/classification/test_time.py
@@ -3,6 +3,7 @@ import torch
 import logging
 import numpy as np
 import methods
+from quantization.quantizer import apply_quantization
 
 from models.model import get_model
 from utils.misc import print_memory_info
@@ -32,6 +33,7 @@ def evaluate(description):
 
     # get the base model and its corresponding input pre-processing (if available)
     base_model, model_preprocess = get_model(cfg, num_classes, device)
+    base_model = apply_quantization(base_model)
 
     # append the input pre-processing to the base model
     base_model.model_preprocess = model_preprocess

--- a/quantization/__init__.py
+++ b/quantization/__init__.py
@@ -1,0 +1,3 @@
+from .quantizer import apply_quantization
+
+__all__ = ["apply_quantization"]

--- a/quantization/quantizer.py
+++ b/quantization/quantizer.py
@@ -1,0 +1,43 @@
+import torch
+import torch.nn as nn
+
+
+def _ste_round(x: torch.Tensor) -> torch.Tensor:
+    """Round with Straight Through Estimator for the backward pass."""
+    return (x.round() - x).detach() + x
+
+
+def _fake_quantize(tensor: torch.Tensor, bits: int = 8) -> torch.Tensor:
+    """Quantize with STE-based fake quantization."""
+    if tensor.numel() == 0:
+        return tensor
+    qmin = -(2 ** (bits - 1))
+    qmax = 2 ** (bits - 1) - 1
+    max_val = tensor.abs().max()
+    scale = max_val / qmax if max_val != 0 else 1.0
+    return torch.clamp(_ste_round(tensor / scale), qmin, qmax) * scale
+
+
+def _quantize_module_params(module: nn.Module, bits: int) -> None:
+    """Quantize parameters of the given module in-place."""
+    for name, param in module.named_parameters(recurse=False):
+        if param is not None:
+            param.data = _fake_quantize(param.data, bits)
+
+
+def _activation_pre_hook(module: nn.Module, inputs, bits: int):
+    return (_fake_quantize(inputs[0], bits),)
+
+
+def _activation_post_hook(module: nn.Module, inputs, output, bits: int):
+    return _fake_quantize(output, bits)
+
+
+def apply_quantization(model: nn.Module, weight_bits: int = 8, act_bits: int = 8) -> nn.Module:
+    """Apply fake quantization with STE to weights and activations of conv/linear layers."""
+    for module in model.modules():
+        if isinstance(module, (nn.Conv2d, nn.Linear)):
+            _quantize_module_params(module, weight_bits)
+            module.register_forward_pre_hook(lambda m, inp, b=act_bits: _activation_pre_hook(m, inp, b))
+            module.register_forward_hook(lambda m, inp, out, b=act_bits: _activation_post_hook(m, inp, out, b))
+    return model

--- a/segmentation/test_time.py
+++ b/segmentation/test_time.py
@@ -21,6 +21,7 @@ from methods.cotta import CoTTA
 from methods.gtta import GTTA
 from methods.asm import ASM
 from methods.sm_ppm import SMPPM
+from quantization.quantizer import apply_quantization
 
 os.environ["WANDB_MODE"] = "offline"
 logger = logging.getLogger(__name__)
@@ -51,6 +52,7 @@ def main(description):
                             imagenet_init=cfg.MODEL.IMAGENET_INIT,
                             num_classes=cfg.MODEL.NUM_CLASSES,
                             model_name=cfg.MODEL.NAME)
+    base_model = apply_quantization(base_model)
 
     # setup test data loader
     test_loader = create_carla_loader(data_dir=cfg.DATA_DIR,


### PR DESCRIPTION
## Summary
- rename quantization module and export `apply_quantization`
- implement straight-through estimator rounding for weights and activations
- apply new quantizer in classification and segmentation scripts

## Testing
- `python -m py_compile classification/test_time.py segmentation/test_time.py quantization/quantizer.py`


------
https://chatgpt.com/codex/tasks/task_e_68884da80da8832a90cae5ca850ace76