### PR TITLE
Enable quantization configuration and add benchmark script

### DIFF
--- a/classification/conf.py
+++ b/classification/conf.py
@@ -294,6 +294,18 @@ _C.TPT.N_CTX = 4                    # Number of tunable context tokens
 _C.TPT.CTX_INIT = "a_photo_of_a"    # Context initialization
 _C.TPT.CLASS_TOKEN_POS = "end"      # Position of the class token. Choose from: [end, middle, front]
 
+# --------------------------------- Quantization options -------------------- #
+_C.QUANT = CfgNode()
+
+# Whether to apply fake quantization
+_C.QUANT.QUANTIZE = False
+
+# Number of bits used for weights
+_C.QUANT.WEIGHT_BITS = 8
+
+# Number of bits used for activations
+_C.QUANT.ACTIVATION_BITS = 8
+
 # ------------------------------- Source options -------------------------- #
 _C.SOURCE = CfgNode()
 

--- a/classification/scripts/run_quant.sh
+++ b/classification/scripts/run_quant.sh
@@ -1,0 +1,60 @@
+#!/bin/bash -l
+
+conda activate tta
+
+datasets=(
+    "cifar10_c"
+    "cifar100_c"
+    "imagenet_c"
+)
+
+methods=(
+    "ttn"
+)
+
+setting=reset_each_shift
+batches=(128 64 32 16 8 4 2 1)
+seeds=(1)
+options=()
+
+combinations=(
+    "16 16"
+    "8 8"
+    "4 8"
+    "4 4"
+)
+
+for dataset in "${datasets[@]}"; do
+    for method in "${methods[@]}"; do
+        for combo in "${combinations[@]}"; do
+            read -r w_bit a_bit <<< "$combo"
+            echo "w_bit:${w_bit}, a_bit:${a_bit}"
+
+            for batch in ${batches[*]}; do
+                for seed in ${seeds[*]}; do
+                    if [ "$w_bit" -eq 16 ] && [ "$a_bit" -eq 16 ]; then
+                        CUDA_VISIBLE_DEVICES=0 python test_time.py \
+                            --cfg "cfgs/$dataset/$method.yaml" \
+                            SETTING $setting \
+                            RNG_SEED $seed DETERMINISM True \
+                            TEST.BATCH_SIZE $batch \
+                            CORRUPTION.SEVERITY 1,2,3,4,5 \
+                            QUANT.QUANTIZE False \
+                            SAVE_DIR "./exp_alpha/w${w_bit}a${a_bit}/"
+                    else
+                        CUDA_VISIBLE_DEVICES=0 python test_time.py \
+                            --cfg "cfgs/$dataset/$method.yaml" \
+                            SETTING $setting \
+                            RNG_SEED $seed DETERMINISM True \
+                            TEST.BATCH_SIZE $batch \
+                            CORRUPTION.SEVERITY 1,2,3,4,5 \
+                            QUANT.QUANTIZE True \
+                            QUANT.WEIGHT_BITS $w_bit \
+                            QUANT.ACTIVATION_BITS $a_bit \
+                            SAVE_DIR "./exp_alpha/w${w_bit}a${a_bit}/"
+                    fi
+                done
+            done
+        done
+    done
+done

--- a/classification/test_time.py
+++ b/classification/test_time.py
@@ -33,7 +33,14 @@ def evaluate(description):
 
     # get the base model and its corresponding input pre-processing (if available)
     base_model, model_preprocess = get_model(cfg, num_classes, device)
-    base_model = apply_quantization(base_model)
+
+    # optionally apply fake quantization
+    if cfg.QUANT.QUANTIZE:
+        base_model = apply_quantization(
+            base_model,
+            weight_bits=cfg.QUANT.WEIGHT_BITS,
+            act_bits=cfg.QUANT.ACTIVATION_BITS,
+        )
 
     # append the input pre-processing to the base model
     base_model.model_preprocess = model_preprocess

--- a/segmentation/conf.py
+++ b/segmentation/conf.py
@@ -163,6 +163,18 @@ _C.GTTA.PRETRAIN_STEPS_ADAIN = 20000
 _C.GTTA.USE_STYLE_TRANSFER = True
 _C.GTTA.LAMBDA_CE_TRG = 0.1
 
+# --------------------------------- Quantization options -------------------- #
+_C.QUANT = CfgNode()
+
+# Whether to apply fake quantization
+_C.QUANT.QUANTIZE = False
+
+# Number of bits used for weights
+_C.QUANT.WEIGHT_BITS = 8
+
+# Number of bits used for activations
+_C.QUANT.ACTIVATION_BITS = 8
+
 
 # ------------------------------- Source options ---------------------------- #
 _C.SOURCE = CfgNode()

--- a/segmentation/test_time.py
+++ b/segmentation/test_time.py
@@ -52,7 +52,13 @@ def main(description):
                             imagenet_init=cfg.MODEL.IMAGENET_INIT,
                             num_classes=cfg.MODEL.NUM_CLASSES,
                             model_name=cfg.MODEL.NAME)
-    base_model = apply_quantization(base_model)
+
+    if cfg.QUANT.QUANTIZE:
+        base_model = apply_quantization(
+            base_model,
+            weight_bits=cfg.QUANT.WEIGHT_BITS,
+            act_bits=cfg.QUANT.ACTIVATION_BITS,
+        )
 
     # setup test data loader
     test_loader = create_carla_loader(data_dir=cfg.DATA_DIR,


### PR DESCRIPTION
## Summary
- add quantization options to classification and segmentation configs
- allow optional quantization in `test_time.py` files
- provide script `run_quant.sh` to compare TTA methods with different bit widths and batch sizes

## Testing
- `python -m py_compile classification/conf.py segmentation/conf.py classification/test_time.py segmentation/test_time.py`

------
https://chatgpt.com/codex/tasks/task_e_6889aa77cd54832a8ff90a3d69a2248b